### PR TITLE
certificate-authority: don't sign ceritficate which contains hubId in…

### DIFF
--- a/content/en/configuration/certificate-authority.md
+++ b/content/en/configuration/certificate-authority.md
@@ -73,5 +73,6 @@ Signer configuration to issue identity certificates for devices or mobile applic
 | `signer.certFile` | string | `File path to the signer certificate in PEM format.` |  `""` |
 | `signer.validFrom` | string | `The time from when the certificate is valid. (Format: https://github.com/karrick/tparse)` |  `"now-1h"` |
 | `signer.expiresIn` | string | `The time up to which the certificate is valid.` |  `"87600h"` |
+| `signer.hubId` | string | `Hub ID which is stored in coap-gw certificate and it cannot be used in the common name in the CSR.` | `""` |
 
 > Note that the string type related to time (i.e. timeout, idleConnTimeout, expirationTime) is decimal numbers, each with optional fraction and a unit suffix, such as "300ms", "1.5h" or "2h45m". Valid time units are "ns", "us", "ms", "s", "m", "h".


### PR DESCRIPTION
… common name